### PR TITLE
Moving Reset Data to Main State

### DIFF
--- a/components/ApiFavourites.tsx
+++ b/components/ApiFavourites.tsx
@@ -1,38 +1,24 @@
-interface DEMO_CONTENT_F {
+import { store } from './redux/store';
+
+interface FAVOURITE_ITEM {
       id: String;
       title: String;
       image: String;
-      review: Number;
+      votes: Number;
     }
   
-    const DEMO_CONTENT_F = [
-      {
-        id: "13811970880719370165",
-        title: "Archie's",
-        image:
-          "https://lh5.googleusercontent.com/p/AF1QipOU6HCJ8Ii3RERoT0yyOsFGI8Y3Tf_R31VhMOMP=w1920-h1080-k-no",
-        votes: 1,
-      },
-      {
-        id: "15743151851868695548",
-        title: "Döner Summer Manchester",
-        image:
-          "https://lh5.googleusercontent.com/p/AF1QipO-ige5X_x8mDoQT2L2O1w8jqNatTkPd4DLEXeO=w1920-h1080-k-no",
-        votes: 2,
-      },
-      {
-        id: "13811970880719370165A",
-        title: "Archie's",
-        image:
-          "https://lh5.googleusercontent.com/p/AF1QipOU6HCJ8Ii3RERoT0yyOsFGI8Y3Tf_R31VhMOMP=w1920-h1080-k-no",
-        votes: 3,
-      },
-      {
-        id: "15743151851868695548A",
-        title: "Döner Summer Manchester",
-        image:
-          "https://lh5.googleusercontent.com/p/AF1QipO-ige5X_x8mDoQT2L2O1w8jqNatTkPd4DLEXeO=w1920-h1080-k-no",
-        votes: 4,
-      }]
-
-      export default DEMO_CONTENT_F
+export default function favouriteData(): FAVOURITE_ITEM[] {
+    const storeStates = (store.getState());
+    const favouriteState = storeStates.favourited;
+    const favouritedRestaurants = favouriteState.restaurants;
+    const returnedRestaurants = favouritedRestaurants.map(({id, title, image, votes}: FAVOURITE_ITEM) => {
+      return {
+        id, 
+        title,
+        image,
+        votes
+      }
+    })
+      return returnedRestaurants;
+    }
+    

--- a/components/Favourites.tsx
+++ b/components/Favourites.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Text } from "react-native";
 import styles from "./styles";
 import ListTemplate from "./ListTemplate";
-
+import { resetFavourite } from "./redux/action";
 import DEMO_CONTENT_F from "./ApiFavourites";
 
 export default function Favourites() {

--- a/components/Interested.tsx
+++ b/components/Interested.tsx
@@ -1,32 +1,48 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Text, Pressable } from "react-native";
 import styles from "./styles";
 import ListTemplate from "./ListTemplate";
 import { useDispatch, useSelector } from 'react-redux';
-import { resetInterested } from "./redux/action";
-import { store } from './redux/store';
+import { resetInterested, resetMain } from "./redux/action";
 import { useNavigation } from "@react-navigation/native";
 import INTERESTED_CONTENT from "./ApiInterested";
+import { addToMain } from './redux/action';
 
 export default function Interested () {
 
+    interface Restaurant {
+      id: string
+      title: string
+      image: string
+      votes: number
+    }
+
     const navigation = useNavigation();
     const dispatch = useDispatch();
-    const interestedInitialState = useSelector(interestedInitialState => interestedInitialState)
+    const globalState = useSelector(globalState => globalState)
+    const [localIntState, setLocalIntState] = useState([]);
 
     useEffect(() => {
       INTERESTED_CONTENT();
-    },[interestedInitialState])
+      setLocalIntState(globalState.interested.restaurants);
+    },[globalState])
 
-    const handleResetInterested = () => {
+    const handleResetInterested = (localIntState: Restaurant[]) => {
+        dispatch(addToMain(globalState.interested.restaurants));
         dispatch(resetInterested);
-        const storeStates = (store.getState());
-        console.log(storeStates, '< all state');
-        console.log(storeStates.notInterested);
+      }
+
+      const handleResetMain = () => {
+        console.log(globalState, '<< MAIN STATE')
+        dispatch(resetMain);
       }
 
     return (
     <>
+        <Pressable onPress={ handleResetMain } style={styles.button}>
+          <Text style={styles.buttonText}>RESET MAIN</Text>
+        </Pressable>
+
         <Pressable onPress={ handleResetInterested } style={styles.button}>
           <Text style={styles.buttonText}>RESET INTERESTED</Text>
         </Pressable>

--- a/components/NotInterested.tsx
+++ b/components/NotInterested.tsx
@@ -1,23 +1,33 @@
-import React, { useEffect }from "react";
+import React, { useEffect, useState }from "react";
 import { View, Text, Pressable } from "react-native";
 import ListTemplate from "./ListTemplate";
 import styles from "./styles";
 import { useDispatch, useSelector } from 'react-redux';
-import { resetNotInterested } from "./redux/action";
+import { addToMain, resetNotInterested } from "./redux/action";
 import { useNavigation } from "@react-navigation/native";
 import NI_CONTENT from "./ApiNotInterested";
 
 export default function NotInterested () {
     
+    interface Restaurant {
+      id: string
+      title: string
+      image: string
+      votes: number
+    }
+
     const navigation = useNavigation()
     const dispatch = useDispatch();
-    const niInitialState = useSelector(notInterestedInitialState => notInterestedInitialState)
+    const globalState = useSelector(globalState => globalState)
+    const [localNiState, setLocalNiState] = useState([]);
 
     useEffect(() => {
        NI_CONTENT();
-    }, [niInitialState])
+       setLocalNiState(globalState.notInterested.restaurants);
+    }, [globalState])
 
-    const handleResetNotInterested = () => {
+    const handleResetNotInterested = (localNiState: Restaurant[]) => {
+      dispatch(addToMain(globalState.notInterested.restaurants))
       dispatch(resetNotInterested);
     }
 

--- a/components/RestaurantCard.tsx
+++ b/components/RestaurantCard.tsx
@@ -52,8 +52,6 @@ function RestaurantCard({
 		dispatch(addNotInterested(item));
 		const storeStates = store.getState();
 		const notInterestedState = storeStates.notInterested;
-		console.log(notInterestedState);
-		// console.log(notInterestedState.restaurants.length,'<< not interested array length')
 		setNotInterested({});
 	};
 
@@ -61,7 +59,6 @@ function RestaurantCard({
 		dispatch(addInterested(item));
 		const storeStates = store.getState();
 		const interestedState = storeStates.interested;
-		// console.log(interestedState.restaurants.length,'<< interested array length')
 		setInterested({});
 	};
 

--- a/components/redux/action.ts
+++ b/components/redux/action.ts
@@ -2,6 +2,11 @@ export const ADD_INTERESTED = "ADD_INTERESTED";
 export const ADD_NOT_INTERESTED = "ADD_NOT_INTERESTED";
 export const RESET_INTERESTED = "RESET_INTERESTED";
 export const RESET_NOT_INTERESTED = "RESET_NOT_INTERESTED";
+export const ADD_TO_MAIN="ADD_TO_MAIN";
+export const ADD_FAVOURITE="ADD_FAVOURITE";
+export const RESET_FAVOURITE="REMOVE_FAVOURITE";
+export const REMOVE_FAVOURITE="REMOVE_FAVOURITE";
+export const RESET_MAIN="RESET_MAIN";
 
 let interestedID = 0;
 let notInterestedID = 0;
@@ -12,10 +17,31 @@ interface Restaurant {
     image: String;
     review: Number;
 }
+
+export const resetMain = {
+    type: RESET_MAIN
+}
+
+export const addToMain = (state: Restaurant[]) => ({
+    type: ADD_TO_MAIN,
+    payload: {
+        restaurants: state
+    }
+});
+
+export const addToFavourite = (item: Restaurant) => ({
+    type: ADD_FAVOURITE,
+    payload: {
+        restaurant: item
+    }
+})
+
+export const resetFavourite = {
+    type: RESET_FAVOURITE
+}
 export const resetNotInterested = {
     type: RESET_NOT_INTERESTED
 }
-
 export const resetInterested = {
     type: RESET_INTERESTED
 }
@@ -23,7 +49,6 @@ export const resetInterested = {
 export const addNotInterested = (item: Restaurant) => ({
     type: ADD_NOT_INTERESTED,
     payload: {
-        id: ++notInterestedID,
         restaurant: item
     }
 })
@@ -31,7 +56,6 @@ export const addNotInterested = (item: Restaurant) => ({
 export const addInterested = (item: Restaurant) => ({
     type: ADD_INTERESTED,
     payload: {
-        id: ++interestedID,
         restaurant: item
     }
 })

--- a/components/redux/reducer.ts
+++ b/components/redux/reducer.ts
@@ -1,6 +1,7 @@
 import { ADD_NOT_INTERESTED, RESET_NOT_INTERESTED } from "./action";
 import { ADD_INTERESTED, RESET_INTERESTED } from "./action";
-
+import { ADD_FAVOURITE, RESET_FAVOURITE, REMOVE_FAVOURITE } from "./action";
+import { ADD_TO_MAIN, RESET_MAIN } from './action'
 export const notInterestedInitialState = {
     restaurants: []
 }
@@ -8,22 +9,43 @@ export const notInterestedInitialState = {
 export const interestedInitialState = {
     restaurants: []
 }
-export const notInterestedReducer = (state = notInterestedInitialState, action) => {
-    switch (action.type) {
-        case ADD_NOT_INTERESTED: {
+
+export const mainInitialState = {
+    restaurants: []
+}
+
+export const favouriteInitialState = {
+    restaurants: []
+}
+
+export const favouriteReducer = (state = favouriteInitialState, action) => {
+    switch(action.type) {
+
+        case ADD_FAVOURITE: {
             const { restaurant } = action.payload;
             return {
                 ...state,
-                restaurants: [...state.restaurants, restaurant ]
-            };
+                restaurants: [...state.restaurants, restaurant]
+            }
         }
-        case RESET_NOT_INTERESTED: {
-            return { ...notInterestedInitialState };
+
+        case REMOVE_FAVOURITE: {
+            const { restaurant } = action.payload;
+            const filteredRestaurants = [...state.restaurants].filter(restaurant => restaurant.id !== restaurant.id )
+            return {
+                filteredRestaurants
+            }
         }
+
+        case RESET_FAVOURITE: {
+            return {...favouriteInitialState};
+        }
+         
         default: {
             return state;
         }
     }
+    
 }
 
 export const interestedReducer = (state = interestedInitialState, action) => {
@@ -42,3 +64,41 @@ export const interestedReducer = (state = interestedInitialState, action) => {
             return state;
     }
 }
+
+export const mainReducer = (state = mainInitialState, action) => {
+    switch (action.type) {
+        case RESET_MAIN: {
+            return {...mainInitialState};
+        }
+        case ADD_TO_MAIN: {
+            const  restaurantie  = action.payload;
+            return {
+                restaurants: [...restaurantie.restaurants, ...state.restaurants]
+            }
+        }
+        
+        default: {
+            return state;
+        }
+    }
+}
+
+export const notInterestedReducer = (state = notInterestedInitialState, action, main = mainInitialState) => {
+    switch (action.type) {
+        case ADD_NOT_INTERESTED: {
+            const { restaurant } = action.payload;
+            return {
+                ...state,
+                restaurants: [...state.restaurants, restaurant ]
+            };
+        }
+        case RESET_NOT_INTERESTED: {
+            return {...notInterestedInitialState}
+        }
+
+        default: {
+            return state;
+        }
+    }
+}
+

--- a/components/redux/store.ts
+++ b/components/redux/store.ts
@@ -1,5 +1,5 @@
-import { legacy_createStore as createStore, combineReducers } from 'redux'
-import { interestedReducer, notInterestedReducer } from './reducer'
+import { legacy_createStore as createStore, combineReducers, applyMiddleware } from 'redux'
+import { interestedReducer, notInterestedReducer, mainReducer, favouriteReducer } from './reducer'
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { persistStore, persistReducer } from 'redux-persist'
 import storage from 'redux-persist/lib/storage' 
@@ -10,7 +10,7 @@ const persistConfig = {
 }
 
 //Combines the interestedReducer and notInterestedReducer into a single Reducer
-const rootReducer = combineReducers({interested: interestedReducer, notInterested: notInterestedReducer})
+const rootReducer = combineReducers({interested: interestedReducer, notInterested: notInterestedReducer, main: mainReducer, favourited: favouriteReducer})
 //Creates a persisted reducer using the config and above combined reducer
 const persistedReducer = persistReducer(persistConfig, rootReducer)
 


### PR DESCRIPTION
For this PR we have done the following: 

1. Persistently stores interested/not interested and main states
2. If you press reset any of the lists it will return the data to the main state

Doing now:
* Checks if int/not int/main/favourites have anything - if it doesnt will fetch for data
* If data exists, then wont fetch and data from homepage will come from main