### PR TITLE
Fixed favouriting of restaurants on interested/not-interested cards.

### DIFF
--- a/components/ExtendedCard.tsx
+++ b/components/ExtendedCard.tsx
@@ -54,16 +54,17 @@ const data  = props.selectedItem ? props.selectedItem : props.item
   const favouritedState = globalState.favourited.restaurants;
   const dispatch = useDispatch();
   const [favourited, setFavourited] = useState({})
-  
+
   const handleAddFavourited = () => {
-  if(favouritedState.includes(props.item)) {
-    return
+    if (Object.keys(favourited).length === 0) {
+      setFavourited(props.selectedItem);
+      dispatch(addToFavourite(props.selectedItem));
+      console.log('Added item');
+    } else if (Object.keys(favourited).length !== 0) {
+      console.log('Already favourited')
+      return;
+    }
   }
-  else {
-    dispatch(addToFavourite(props.item));
-    setFavourited({});
-  }
-};
 
   return (
     <Modal


### PR DESCRIPTION
Added preventative measure so that the user cannot add anymore of the same items that they have favourited - and you are now able to favourite from the interested/non-interested list.

However, if you try to click the favourite button from the extended card from the favourites list it will still add one more duplicate, so just don't try and press the favourite button from an extended card from the favourites list.